### PR TITLE
chore: drop Node v12 support because of the EOL

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
       - name: Setup node
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v3.4.1
         with:
           node-version: 12.x
       - run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,14 +4,14 @@ on: [push]
 
 jobs:
   build:
-    name: Node.js ubuntu-latest 12.x
+    name: Node.js ubuntu-latest 14.x
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
       - name: Setup node
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: |
           npm ci
           npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     name: Node.js ubuntu-latest 12.x
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v3.0.2
       - name: Setup node
         uses: actions/setup-node@v2.0.0
         with:

--- a/.github/workflows/shipjs-manual-prepare.yml
+++ b/.github/workflows/shipjs-manual-prepare.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
-      - uses: actions/setup-node@v2.0.0
+      - uses: actions/setup-node@v3.4.1
         with:
           node-version: 12.x
       - run: |

--- a/.github/workflows/shipjs-manual-prepare.yml
+++ b/.github/workflows/shipjs-manual-prepare.yml
@@ -10,7 +10,7 @@ jobs:
       startsWith(github.event.comment.body, '@shipjs prepare')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
           ref: master

--- a/.github/workflows/shipjs-manual-prepare.yml
+++ b/.github/workflows/shipjs-manual-prepare.yml
@@ -16,7 +16,7 @@ jobs:
           ref: master
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: |
           if [ -f "yarn.lock" ]; then
             yarn install

--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
-      - uses: actions/setup-node@v2.0.0
+      - uses: actions/setup-node@v3.4.1
         with:
           node-version: 12.x
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -15,7 +15,7 @@ jobs:
           ref: master
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12.x
+          node-version: 14.x
           registry-url: "https://registry.npmjs.org"
       - run: |
           if [ -f "yarn.lock" ]; then

--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'releases/v')
     steps:
-      - uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
           ref: master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Node.js ${{ matrix.os }} ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v3.0.2
       - name: Setup node
         uses: actions/setup-node@v2.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
       - name: Setup node
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v3.4.1
         with:
           node-version: ${{ matrix.node-version }}
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x]
+        node-version: [14.x, 16.x]
     name: Node.js ${{ matrix.os }} ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/miyajan/garoon-rest",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.10.3",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Because Node v12 has been in EOL since April 30th.
CI/CD workflows failed because of using Node v12 which `setup-node` stopped supporting. 

## What

<!-- What is a solution you want to add? -->

- [x] drop Node v12 from the `engines` of `package.json`.
  - from this PR, the oldest supported version is v14.
- [x] update Node version in CI ( [12, 14] -> [14, 16])

Also, I updated following actions

- actions/checkout: v2.3.1->v3.0.2
- actions/setup-node v2.0.0->v3.4.1

## How to test

<!-- How can we test this pull request? -->

```
npm ci

npm run lint
npm run test
```